### PR TITLE
-Fixed inventoriable id column on scopes

### DIFF
--- a/tests/HasInventoryTest.php
+++ b/tests/HasInventoryTest.php
@@ -153,6 +153,23 @@ class HasInventoryTest extends TestCase
     }
 
     /** @test */
+    public function scope_to_find_where_inventory_is_the_parameters_passed_to_the_scope_in_multiple_models()
+    {
+        $this->secondInventoryModel->setInventory(20);
+
+        $this->assertEquals(0, $this->inventoryModel->inventories->first()->quantity);
+        $this->assertEquals(20, $this->secondInventoryModel->inventories->first()->quantity);
+
+        $this->assertEquals($this->inventoryModel->id, InventoryModel::InventoryIs(0, '=', [1, 2])->get()->first()->id);
+        $this->assertCount(1, InventoryModel::InventoryIs(0, '=', [1, 2])->get());
+
+        $this->assertEquals(20, $this->secondInventoryModel->inventories->first()->quantity);
+        $this->assertEquals($this->secondInventoryModel->id, InventoryModel::InventoryIs(20, '=', [1, 2])->get()->first()->id);
+
+        $this->assertCount(1, InventoryModel::InventoryIs(20, '=', [1, 2])->get());
+    }
+
+    /** @test */
     public function scope_to_find_where_inventory_is_the_opposite_then_parameters_passed_to_the_scope()
     {
         $this->assertEquals(0, $this->inventoryModel->inventories->first()->quantity);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,8 @@ abstract class TestCase extends BaseTest
 {
     protected $inventoryModel;
 
+    protected $secondInventoryModel;
+
     /**
      * Define environment setup.
      *
@@ -45,6 +47,8 @@ abstract class TestCase extends BaseTest
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
         $this->inventoryModel = InventoryModel::first();
+
+        $this->secondInventoryModel = InventoryModel::find(2);
     }
 
     protected function setUpDatabase($app)
@@ -69,6 +73,10 @@ abstract class TestCase extends BaseTest
 
         InventoryModel::create([
             'name' => 'InventoryModel',
+        ]);
+
+        InventoryModel::create([
+            'name' => 'SecondInventoryModel',
         ]);
 
         Inventory::create([


### PR DESCRIPTION
-Fixed inventoriable id column on scopes
Scopes reach for ```$this->getModelKeyColumnName()``` instead of hardcoded ``` 'inventoriable_id'``` column name on scopes.

-Added test to verify scopes work with arrays of models