### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,10 +1,6 @@
 name: Laravel-Inventory Test
 
-on:
-  push:
-    branches: [ master, develop ]
-  pull_request:
-    branches: [ master, develop ]
+on: [push, pull_request]
 
 jobs:
   laravel-tests:
@@ -13,12 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 8.1, 8.2]
-        laravel: [9, 10]
+        php: [8.2, 8.1, 8.0]
+        laravel: [9.*, 10.*]
         dependency-vesrion: [prefer-lowest, prefer-stable]
         include:
          -   laravel: 10.*
-             testbench: 8.*
+             testbench: ^8.0
          -   laravel: 9.*
              testbench: 7.*
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "illuminate/support": "^9.0|^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
         "orchestra/testbench": "^7.0|^8.0",
         "pestphp/pest": "^1.22",
         "laravel/pint": "^1.4"

--- a/src/Inventory.php
+++ b/src/Inventory.php
@@ -11,6 +11,10 @@ class Inventory extends Model
 
     protected $table = 'inventories';
 
+    protected $casts = [
+        'quantity' => 'integer',
+    ];
+
     /**
      * Relationship.
      *


### PR DESCRIPTION
This PR updates workflows. 
- Fix support for PHP 8.0 with Laravel 9 by casting quantity to an integer.
- Dropping `phpunit` as a dev dependency, as it is a dependency of `pest`